### PR TITLE
Fusion base box added

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,12 +38,21 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.box = "ubuntu/trusty64"
+  #config.vm.box = "jdowning/trusty64"
   config.vm.network :forwarded_port, guest: 5601, host: 5601
   config.vm.network :forwarded_port, guest: 9200, host: 9200
   config.vm.network :forwarded_port, guest: 9300, host: 9300
+  
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--cpus", "2", "--memory", "2048"]
   end
+
+  config.vm.provider "vmware_fusion" do |v, override|
+    override.vm.box = "phusion/ubuntu-14.04-amd64"
+    v.vmx["numvcpus"] = "2"
+    v.vmx["memsize"] = "2048"
+  end
+
   config.vm.provision "shell", inline: $script
   config.vm.provision "puppet", manifests_path: "manifests", manifest_file: "default.pp"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,8 +37,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vbguest.auto_update = true
   end
 
-  config.vm.box = "ubuntu/trusty64"
-  #config.vm.box = "jdowning/trusty64"
+  config.vm.box = "phusion/ubuntu-14.04-amd64"
   config.vm.network :forwarded_port, guest: 5601, host: 5601
   config.vm.network :forwarded_port, guest: 9200, host: 9200
   config.vm.network :forwarded_port, guest: 9300, host: 9300
@@ -48,7 +47,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.provider "vmware_fusion" do |v, override|
-    override.vm.box = "phusion/ubuntu-14.04-amd64"
     v.vmx["numvcpus"] = "2"
     v.vmx["memsize"] = "2048"
   end


### PR DESCRIPTION
I've used the `phusion/ubuntu-14.04-amd64` box on fusion and it appears to support virtualbox too so thought i'd submit a PR to make that the base box for all providers.

One thing I noticed with OSX was that I had to use `sudo` before any vagrant commands. Not sure what thats about