### PR TITLE
Make kibana start on boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If kibana for some reason should fail to start, start it manually using
 
 ```bash
 
-/opt/kibana/kibana-4.0.0-linux-x64/bin/kibana
+/opt/kibana/bin/kibana
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If kibana for some reason should fail to start, start it manually using
 
 ```bash
 
-/vagrant/kibana/kibana-4.0.0-linux-x64/bin/kibana
+/opt/kibana/kibana-4.0.0-linux-x64/bin/kibana
 
 ```
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,6 +28,11 @@ fi
 if [ ! -d /etc/puppet/modules/logstash ]; then
 puppet module install elasticsearch-logstash
 fi
+if [ ! -f /etc/init.d/kibana ]; then
+sudo cp /vagrant/kibana4_init /etc/init.d/kibana
+sudo chmod +x /etc/init.d/kibana
+sudo update-rc.d kibana defaults
+fi
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|

--- a/kibana4_init
+++ b/kibana4_init
@@ -1,0 +1,87 @@
+#!/bin/sh
+#
+# /etc/init.d/kibana4_init -- startup script for kibana4
+# bsmith@the408.com 2015-02-20; used elasticsearch init script as template
+# https://github.com/akabdog/scripts/edit/master/kibana4_init
+#
+### BEGIN INIT INFO
+# Provides:          kibana4_init
+# Required-Start:    $network $remote_fs $named
+# Required-Stop:     $network $remote_fs $named
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Starts kibana4_init
+# Description:       Starts kibana4_init using start-stop-daemon
+### END INIT INFO
+
+#configure this with wherever you unpacked kibana:
+KIBANA_BIN=/opt/kibana/bin
+
+NAME=kibana4
+PID_FILE=/var/run/$NAME.pid
+PATH=/bin:/usr/bin:/sbin:/usr/sbin:$KIBANA_BIN
+DAEMON=$KIBANA_BIN/kibana
+DESC="Kibana4"
+
+if [ `id -u` -ne 0 ]; then
+    echo "You need root privileges to run this script"
+    exit 1
+fi
+
+. /lib/lsb/init-functions
+
+if [ -r /etc/default/rcS ]; then
+    . /etc/default/rcS
+fi
+
+case "$1" in
+  start)
+    log_daemon_msg "Starting $DESC"
+
+    pid=`pidofproc -p $PID_FILE kibana`
+    if [ -n "$pid" ] ; then
+        log_begin_msg "Already running."
+        log_end_msg 0
+        exit 0
+    fi
+
+    # Start Daemon
+    start-stop-daemon --start --pidfile "$PID_FILE" --make-pidfile --background --exec $DAEMON
+    log_end_msg $?
+    ;;
+  stop)
+    log_daemon_msg "Stopping $DESC"
+
+    if [ -f "$PID_FILE" ]; then
+        start-stop-daemon --stop --pidfile "$PID_FILE" \
+            --retry=TERM/20/KILL/5 >/dev/null
+        if [ $? -eq 1 ]; then
+            log_progress_msg "$DESC is not running but pid file exists, cleaning up"
+        elif [ $? -eq 3 ]; then
+            PID="`cat $PID_FILE`"
+            log_failure_msg "Failed to stop $DESC (pid $PID)"
+            exit 1
+        fi
+        rm -f "$PID_FILE"
+    else
+        log_progress_msg "(not running)"
+    fi
+    log_end_msg 0
+    ;;
+  status)
+    status_of_proc -p $PID_FILE kibana kibana && exit 0 || exit $?
+    ;;
+  restart|force-reload)
+    if [ -f "$PID_FILE" ]; then
+        $0 stop
+        sleep 1
+    fi
+    $0 start
+    ;;
+  *)
+    log_success_msg "Usage: $0 {start|stop|restart|force-reload|status}"
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -68,7 +68,7 @@ package { 'curl':
   require => [ Class['apt'] ],
 }
 
-file { '/vagrant/kibana':
+file { '/opt/kibana':
   ensure => 'directory',
   group  => 'vagrant',
   owner  => 'vagrant',
@@ -76,12 +76,12 @@ file { '/vagrant/kibana':
 
 
 exec { 'download_kibana':
-  command => '/usr/bin/curl -L https://download.elasticsearch.org/kibana/kibana/kibana-4.0.2-linux-x64.tar.gz | /bin/tar xvz -C /vagrant/kibana',
+  command => '/usr/bin/curl -L https://download.elasticsearch.org/kibana/kibana/kibana-4.0.2-linux-x64.tar.gz | /bin/tar xvz -C /opt/kibana',
   require => [ Package['curl'], File['/vagrant/kibana'],Class['elasticsearch'] ],
   timeout     => 1800
 }
 
 exec {'start kibana':
-  command => '/bin/sleep 10 && /vagrant/kibana/kibana-4.0.2-linux-x64/bin/kibana & ',
+  command => '/bin/sleep 10 && /opt/kibana/kibana-4.0.2-linux-x64/bin/kibana & ',
   require => [ Exec['download_kibana']]
 }

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -74,14 +74,13 @@ file { '/opt/kibana':
   owner  => 'vagrant',
 }
 
-
 exec { 'download_kibana':
-  command => '/usr/bin/curl -L https://download.elasticsearch.org/kibana/kibana/kibana-4.0.2-linux-x64.tar.gz | /bin/tar xvz -C /opt/kibana',
-  require => [ Package['curl'], File['/vagrant/kibana'],Class['elasticsearch'] ],
-  timeout     => 1800
+  command => '/usr/bin/curl -L https://download.elasticsearch.org/kibana/kibana/kibana-4.0.2-linux-x64.tar.gz | /bin/tar xvz -C /opt/kibana --strip-components 1',
+  require => [ Package['curl'], File['/opt/kibana'], Class['elasticsearch'] ],
+  timeout => 1800
 }
 
 exec {'start kibana':
-  command => '/bin/sleep 10 && /opt/kibana/kibana-4.0.2-linux-x64/bin/kibana & ',
+  command => '/bin/sleep 10 && /opt/kibana/bin/kibana & ',
   require => [ Exec['download_kibana']]
 }


### PR DESCRIPTION
Kibana could be considered a service, just like elasticsearch. Having to manually start it after every boot gets annoying quickly. A simple init script won't cut it as vagrant mounts `/vagrant` way too late. This PR modifies the puppet manifest to untar kibana into /opt/kibana which can then be started on boot with the init script taken from elastic/kibana#1595. I realize that kibana can no longer be accessed without logging into the host. This should be possible with some vagrant config though.