### PR TITLE
Enable external logstash access with vagrant-elk-box

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ To get started run:
     vagrant up
     vagrant ssh
 
-Elasticsearch will be available on the host machine at [http://localhost:9200/](http://localhost:9200/), Kibana at [http://localhost:5601/](http://localhost:5601/)
-
+- Elasticsearch will be available on the host machine at [http://localhost:9200/](http://localhost:9200/)
+- Kibana will be available on [http://localhost:5601/](http://localhost:5601/)
+- Logstash is available on port 5959 (both UDP and TCP)
+    - Incoming messages with ```message``` prefixed with ```SIRONO_EVENTS``` will be automatically parsed into JSON
 
 ## Vagrant commands
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,8 +47,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network :forwarded_port, guest: 5601, host: 5601
   config.vm.network :forwarded_port, guest: 9200, host: 9200
   config.vm.network :forwarded_port, guest: 9300, host: 9300
-  config.vm.network :forwarded_port, guest: 5959, host: 5959
-  
+  config.vm.network :forwarded_port, guest: 5959, host: 5959, protocol: "tcp"
+  config.vm.network :forwarded_port, guest: 5959, host: 5959, protocol: "udp"
+
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--cpus", "2", "--memory", "2048"]
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,6 +47,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network :forwarded_port, guest: 5601, host: 5601
   config.vm.network :forwarded_port, guest: 9200, host: 9200
   config.vm.network :forwarded_port, guest: 9300, host: 9300
+  config.vm.network :forwarded_port, guest: 5959, host: 5959
   
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--cpus", "2", "--memory", "2048"]

--- a/confs/logstash/logstash.conf
+++ b/confs/logstash/logstash.conf
@@ -1,9 +1,40 @@
 input {
+  udp {
+    port => 5959
+    type => local_logstash
+    codec => plain {
+        charset => "ISO-8859-1"
+    }
+  }
   tcp {
     port => 5959
-#    debug => true
+    type => local_logstash
+    codec => plain {
+        charset => "ISO-8859-1"
+    }
   }
 }
+
+
+filter {
+    if [type] == "local_logstash" {
+        grok {
+            match => {
+                message => "SIRONO_METRICS\s%{GREEDYDATA:jsondata}"
+            }
+            named_captures_only => true
+        }
+
+        if "SIRONO_METRICS" in [message] {
+            json {
+                source => jsondata
+            }
+        }
+    }
+}
+
+
+
 
 output {
   elasticsearch {

--- a/confs/logstash/logstash.conf
+++ b/confs/logstash/logstash.conf
@@ -1,3 +1,4 @@
+# Open Logstash ports on 5959 to local Log stash messages
 input {
   udp {
     port => 5959
@@ -15,7 +16,7 @@ input {
   }
 }
 
-
+# Strip out SIRONO_METRICS prefix and parse into JSON
 filter {
     if [type] == "local_logstash" {
         grok {
@@ -33,9 +34,7 @@ filter {
     }
 }
 
-
-
-
+# Upload to local Elasticsearch and fake the type as 'syslog' to mimic Production
 output {
   elasticsearch {
     index_type => "syslog"

--- a/confs/logstash/logstash.conf
+++ b/confs/logstash/logstash.conf
@@ -1,15 +1,13 @@
 input {
-  file {
-    path => ["/vagrant/example-logs/testlog"]
-    start_position => "beginning"
-    codec => "json"
-    type => "json"
+  tcp {
+    port => 5959
+#    debug => true
   }
 }
 
 output {
   elasticsearch {
-    index_type => "example"
+    index_type => "syslog"
     host => "127.0.0.1"
     cluster => "vagrant_elasticsearch"
     protocol => "http"


### PR DESCRIPTION
Out of the box, ```vagrant-elk-box``` configures Logstash to only parse an example file (local to the VM)

This change will instead:
- Open UDP and TCP ports 5959 to allow external logstash access (from your local OS X machine's ```bph_api``` project)
- Filter and parse ```track_metrics``` event messages appropriately so that they will be stored as JSON within Elasticsearch and Kibana