### PR TITLE
replace 'index_type' with 'document_type'

### DIFF
--- a/confs/logstash/logstash.conf
+++ b/confs/logstash/logstash.conf
@@ -9,7 +9,7 @@ input {
 
 output {
   elasticsearch {
-    index_type => "example"
+    document_type => "example"
     host => "127.0.0.1"
     cluster => "vagrant_elasticsearch"
     protocol => "http"


### PR DESCRIPTION
logstash elasticsearch setting 'index_type' is deprecated, 'document_type'  is recommended