### PR TITLE
Update setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -41,5 +41,5 @@ if [ ! -f /etc/init.d/kibana ]; then
  sudo sed -i 's/\r//' /etc/init.d/kibana
  sudo chmod +x /etc/init.d/kibana
  sudo update-rc.d kibana defaults
- wget -q http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz http://geolite.maxmind.com/download/geoip/database/GeoIPv6.dat.gz http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz http://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz
+ wget -q https://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz https://geolite.maxmind.com/download/geoip/database/GeoIPv6.dat.gz https://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz https://download.maxmind.com/download/geoip/database/asnum/GeoIPASNum.dat.gz
 fi


### PR DESCRIPTION
MaxMind will be requiring HTTPS for all database download requests starting in March 2024.

See [this release note](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023).